### PR TITLE
Add Docker support and automated downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@ __pycache__
 !pyproject.toml
 !README.md
 !requirements.txt
+
+# Docker support:
+!docker-compose.yml
+
+docker/*
+!docker/
+!docker/Dockerfile
+!docker/example.gif
+
+docker/downloads/*
+!docker/downloads/
+!docker/downloads/.placeholder.txt

--- a/README.md
+++ b/README.md
@@ -127,3 +127,27 @@ The following modes are available for videos:
 * `nm3u8dlre`
     * Faster than `ytdlp`
     * Can be obtained from here: https://github.com/nilaoda/N_m3u8DL-RE/releases
+
+### Docker support
+
+`spotify-web-downloader` can also be built and automatically ran in a Docker container.
+
+Requirements:
+
+- Copy your `cookies.txt` file to: `./docker/cookies.txt`
+
+- Copy the list of Spotify URLs that you want to download to: `./docker/urls.txt`
+
+- In a terminal, run:
+
+```sh
+cd spotify-web-downloader
+
+docker compose up
+```
+
+Your files will be downloaded to: `./docker/downloads`
+
+Demo:
+
+![Demo Gif](./docker/example.gif)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+# Docker Compose file for running the Spotify Web Downloader
+#
+# Requirements:
+# - Put `cookies.txt` and `urls.txt` in the `./docker` folder
+# - Run `docker compose up`
+# - Files will be downloaded to `./docker/downloads`
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    volumes:
+      - ./docker/downloads:/app/Spotify
+    user: "1000:1000"
+    command: ["spotify-web-downloader", "-r", "urls.txt"]
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       dockerfile: ./docker/Dockerfile
     volumes:
       - ./docker/downloads:/app/Spotify
+      - ./docker/cookies.txt:/app/cookies.txt
+      - ./docker/urls.txt:/app/urls.txt
     user: "1000:1000"
     command: ["spotify-web-downloader", "-r", "urls.txt"]
   

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,10 +18,6 @@ COPY ./spotify_web_downloader ./spotify_web_downloader
 COPY ./pyproject.toml .
 COPY ./requirements.txt .
 
-# Copy user files
-COPY ./docker/cookies.txt .
-COPY ./docker/urls.txt .
-
 # Add the local user's bin directory to the PATH
 ENV PATH="/home/user/.local/bin:${PATH}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+# Dockerfile for building Spotify Web Downloader image
+
+# Use the official Python image
+FROM python:3.8-slim-buster
+
+# Install ffmpeg
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+ARG UID=1000
+RUN useradd -m -u $UID user
+USER user
+
+WORKDIR /app
+
+# Copy app files
+COPY ./spotify_web_downloader ./spotify_web_downloader
+COPY ./pyproject.toml .
+COPY ./requirements.txt .
+
+# Copy user files
+COPY ./docker/cookies.txt .
+COPY ./docker/urls.txt .
+
+# Add the local user's bin directory to the PATH
+ENV PATH="/home/user/.local/bin:${PATH}"
+
+# Install the app
+RUN pip install --user --no-cache-dir spotify-web-downloader

--- a/docker/downloads/.placeholder.txt
+++ b/docker/downloads/.placeholder.txt
@@ -1,0 +1,1 @@
+# This file is here to preserve the empty `downloads` folder when committing to git


### PR DESCRIPTION
Hi! Thanks so much for creating this utility, I've found it incredibly useful.

I've added Docker support for my own use, and thought you may be interested in it. Feel free to ignore or reject his PR if it doesn't fit your needs :-)

Usage:

- Place your `cookies.txt` in the `./docker` folder

- Add a `./docker/urls.txt` with the Spotify playlist URLs you want to automatically download.

- Run: `docker compose up`

- A docker image with Python + ffmpeg will be built, and will automatically download all playlists in `urls.txt` to the `./docker/downloads/` folder.

Thanks!

Demo:

![example](https://github.com/glomatico/spotify-web-downloader/assets/4674433/a7a5b151-7929-4530-84d3-6218463e218c)

