### PR TITLE
Don't use cookies.txt, just add the sp_dc token as an environment variable or commandline argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ A Python CLI app for downloading songs/music videos/albums/playlists directly fr
 
 ## Prerequisites
 * Python 3.8 or higher
-* The cookies file of your Spotify account (free or premium)
-    * You can get your cookies by using one of the following extensions on your browser of choice at the Spotify website with your account signed in:
-        * Firefox: https://addons.mozilla.org/addon/export-cookies-txt
-        * Chromium based browsers: https://chrome.google.com/webstore/detail/gdocmgbfkjnnpapoeobnolbbkoibbcif
+* The "sp_dc" token (cookie) of your spotify account (free or premium)
+    * Login to your spotify account in a web browser. Open the developer tools and look for the "sp_dc" token in your cookies. Set this as an environment variable, place it in a .env file or set it via the `--sp-dc-cookie` (short `-c`) commandline option
 * FFmpeg on your system PATH
     * Older versions of FFmpeg may not work.
     * Up to date binaries can be obtained from the links below:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
 pybase62
+python-dotenv
 pywidevine
 pyyaml
 yt-dlp

--- a/spotify_web_downloader/cli.py
+++ b/spotify_web_downloader/cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import dotenv
 import inspect
 import json
 import logging
@@ -124,11 +126,10 @@ def load_config_file(
 )
 # API specific options
 @click.option(
-    "--cookies-path",
+    "--sp-dc-cookie",
     "-c",
-    type=Path,
-    default=spotify_api_sig.parameters["cookies_path"].default,
-    help="Path to .txt cookies file.",
+    type=str,
+    help="sp_dc cookie.",
 )
 # Downloader specific options
 @click.option(
@@ -280,7 +281,7 @@ def main(
     config_path: Path,
     log_level: str,
     print_exceptions: bool,
-    cookies_path: Path,
+    sp_dc_cookie: str,
     output_path: Path,
     temp_path: Path,
     wvd_path: Path,
@@ -304,6 +305,7 @@ def main(
     download_mode_video: DownloadModeVideo,
     no_config_file: bool,
 ) -> None:
+    dotenv.load_dotenv()
     logging.basicConfig(
         format="[%(levelname)-8s %(asctime)s] %(message)s",
         datefmt="%H:%M:%S",
@@ -311,10 +313,12 @@ def main(
     logger = logging.getLogger(__name__)
     logger.setLevel(log_level)
     logger.debug("Starting downloader")
-    if not cookies_path.exists():
-        logger.critical(X_NOT_FOUND_STRING.format("Cookies file", cookies_path))
+    if not sp_dc_cookie:
+        sp_dc_cookie = os.getenv("SP_DC_COOKIE")
+    if not sp_dc_cookie:
+        logger.critical("Environment variable or commandline argument for sp_dc_cookie not found")
         return
-    spotify_api = SpotifyApi(cookies_path)
+    spotify_api = SpotifyApi(sp_dc_cookie)
     downloader = Downloader(
         spotify_api,
         output_path,

--- a/spotify_web_downloader/spotify_api.py
+++ b/spotify_web_downloader/spotify_api.py
@@ -4,8 +4,6 @@ import functools
 import json
 import re
 import time
-from http.cookiejar import MozillaCookieJar
-from pathlib import Path
 
 import base62
 import requests
@@ -33,17 +31,14 @@ class SpotifyApi:
 
     def __init__(
         self,
-        cookies_path: Path = Path("./cookies.txt"),
+        sp_dc_cookie: str,
     ):
-        self.cookies_path = cookies_path
+        self.sp_dc = sp_dc_cookie
         self._setup_session()
 
     def _setup_session(self):
         self.session = requests.Session()
-        if self.cookies_path:
-            cookies = MozillaCookieJar(self.cookies_path)
-            cookies.load(ignore_discard=True, ignore_expires=True)
-            self.session.cookies.update(cookies)
+        self.session.cookies.set("sp_dc", self.sp_dc)
         self.session.headers.update(
             {
                 "sec-ch-ua": '"Google Chrome";v="123", "Not:A-Brand";v="8", "Chromium";v="123"',


### PR DESCRIPTION
Since the other cookies seem unneccessary, I found it preferable to just use that and set it either via a commandline argument or as an environment variable. Also added the option to use a .env file for convenience. Also, since I plan on using the Spotify API class outside of the cli, I find it a bit "cleaner" to initialize it with an access token instead of a path to a cookies file of which most are not needed.

Thanks a lot for this repo, I've just forked it to implement some changes / extensions of functionality for myself and will submit changes that I think could be generally useful as pull requests. Feel free to modify or reject this PR if you don't like it.